### PR TITLE
composer: release hardlock for minor version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         }
     },
     "require": {
-        "nette/di": "~2.2.0",
+        "nette/di": "~2.2",
         "hostbox/api-payu": "@dev"
     },
     "require-dev": {
         "nette/tester": "~1.0",
-        "nette/nette": "~2.2.0"
+        "nette/nette": "~2.2"
     }
 }


### PR DESCRIPTION
It's better to lock down major version, not minor. Before, Nette 2.3 could not be used.
